### PR TITLE
fix(lint): move docstring before __future__ import to resolve E402

### DIFF
--- a/pulseengine/core/__init__.py
+++ b/pulseengine/core/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """
 pulseengine.core — Headless market intelligence engine.
 
@@ -21,6 +19,8 @@ The v0.3 restructure establishes this foundation for future expansion:
 
 **Public API:**
 """
+
+from __future__ import annotations
 
 # Configuration
 from .config import (


### PR DESCRIPTION
Move module docstring above __future__ import to fix 11 ruff E402 violations.