### PR TITLE
feat(dashboard): auto-refresh UI when background scan completes on st…

### DIFF
--- a/pulseengine/local/dashboard.py
+++ b/pulseengine/local/dashboard.py
@@ -173,6 +173,20 @@ def _maybe_trigger_scan() -> None:
     ).start()
 
 
+@st.fragment(run_every=5)
+def _poll_scan_completion() -> None:
+    """Polls every 5 s while a scan is running and triggers a full page rerun on completion."""
+    state = _get_scan_state()
+    if (
+        not state["running"]
+        and state.get("last_finished", 0) > 0
+        and not st.session_state.get("_scan_rerun_done", False)
+    ):
+        st.session_state["_scan_rerun_done"] = True
+        st.session_state["_scan_refresh_epoch"] = int(st.session_state.get("_scan_refresh_epoch", 0)) + 1
+        st.rerun(scope="app")
+
+
 # ── Navigation history ─────────────────────────────────────────────────────────
 
 # Keys that trigger a history push when they change (the "page identity").
@@ -216,8 +230,15 @@ st.sidebar.checkbox(
 
 if st.session_state.get("_enable_auto_scan", True):
     _maybe_trigger_scan()
-# Rerun once after a background scan completes so the UI picks up fresh data.
+
 _scan_state = _get_scan_state()
+
+# While a scan is running, poll every 5 s for completion and trigger a full page rerun.
+if _scan_state["running"]:
+    _poll_scan_completion()
+
+# Fallback: handles completion detected on the next user-triggered rerun (e.g. if the
+# dashboard was closed and reopened after the scan finished without the fragment active).
 if (
     not _scan_state["running"]
     and _scan_state.get("last_finished", 0) > 0
@@ -241,10 +262,10 @@ def _build_snapshot_price_cache(summary_results: dict) -> tuple[tuple[str, float
     cache_items: list[tuple[str, float]] = []
     for category, assets in TRACKED_ASSETS.items():
         category_rows = summary_results.get(category, {}) if isinstance(summary_results, dict) else {}
-        for asset_name, ticker in assets.items():
+        for asset_name, sym in assets.items():
             change_1d = category_rows.get(asset_name, {}).get("change_1d")
             if change_1d is not None:
-                cache_items.append((ticker, float(change_1d)))
+                cache_items.append((sym, float(change_1d)))
     return tuple(cache_items)
 
 
@@ -440,12 +461,25 @@ st.button(
 
 _stale = is_data_stale(_summary)
 if _stale:
-    st.info("Data is stale. Refresh recommended.")
-
-    if st.button("Refresh now"):
-        st.session_state["_scan_refresh_epoch"] = st.session_state.get("_scan_refresh_epoch", 0) + 1
-        st.session_state["_stale_refresh_triggered"] = True
-        st.rerun()
+    _scan_time = _summary.get("scan_time", "")
+    _age_str = ""
+    if _scan_time:
+        try:
+            _last = dt.datetime.fromisoformat(_scan_time)
+            if _last.tzinfo is None:
+                _last = _last.replace(tzinfo=dt.timezone.utc)
+            _age_secs = int((dt.datetime.now(dt.timezone.utc) - _last).total_seconds())
+            if _age_secs < 3600:
+                _age_str = f"{_age_secs // 60}m ago"
+            elif _age_secs < 86400:
+                _age_str = f"{_age_secs // 3600}h ago"
+            else:
+                _age_str = f"{_age_secs // 86400}d ago"
+        except (ValueError, TypeError):
+            pass
+    _refresh_status = "refreshing in background" if _scan_state["running"] else "background refresh queued"
+    _label = f"last scan {_age_str} · {_refresh_status}" if _age_str else _refresh_status
+    st.caption(f"Showing older data — {_label}")
 
 st.markdown(f"# {selected_asset}")
 st.caption(f"{selected_category}  ·  `{ticker}`  ·  last 30 days")

--- a/tests/test_logic_coverage.py
+++ b/tests/test_logic_coverage.py
@@ -6,12 +6,12 @@ import datetime as dt
 
 import pandas as pd
 
-from config.settings import DEDUP_SIMILARITY_THRESHOLD
-from src.explanation import _detect_contradictions
-from src.news import _jaccard, deduplicate_articles
-from src.price import compute_price_metrics, compute_roc
-from src.sentiment import score_sentiment
-from src.signals import compute_signal_score, correlate_news
+from pulseengine.core.config import DEDUP_SIMILARITY_THRESHOLD
+from pulseengine.core.explanation import _detect_contradictions
+from pulseengine.core.news import _jaccard, deduplicate_articles
+from pulseengine.core.price import compute_price_metrics, compute_roc
+from pulseengine.core.sentiment import score_sentiment
+from pulseengine.core.signals import compute_signal_score, correlate_news
 
 
 def test_compute_price_metrics_known_values(ohlcv_df):
@@ -83,8 +83,8 @@ def test_deduplicate_articles_keeps_first_duplicate_and_unique_entries():
 
 def test_score_sentiment_fallback_path(monkeypatch):
     """Keyword fallback should still produce bounded sentiment output."""
-    monkeypatch.setattr("src.sentiment.VADER_AVAILABLE", False)
-    monkeypatch.setattr("src.sentiment._vader", None)
+    monkeypatch.setattr("pulseengine.core.sentiment.VADER_AVAILABLE", False)
+    monkeypatch.setattr("pulseengine.core.sentiment._vader", None)
 
     s = score_sentiment("surge rally growth profit")
     assert -1.0 <= s["compound"] <= 1.0
@@ -95,11 +95,12 @@ def test_score_sentiment_vader_path(monkeypatch):
     """When VADER is available, score_sentiment should proxy VADER scores."""
 
     class _FakeVader:
-        def polarity_scores(self, _text):
+        @staticmethod
+        def polarity_scores(_text):
             return {"compound": 0.42, "pos": 0.6, "neg": 0.1, "neu": 0.3}
 
-    monkeypatch.setattr("src.sentiment.VADER_AVAILABLE", True)
-    monkeypatch.setattr("src.sentiment._vader", _FakeVader())
+    monkeypatch.setattr("pulseengine.core.sentiment.VADER_AVAILABLE", True)
+    monkeypatch.setattr("pulseengine.core.sentiment._vader", _FakeVader())
 
     s = score_sentiment("any text")
     assert s["compound"] == 0.42
@@ -109,7 +110,7 @@ def test_score_sentiment_vader_path(monkeypatch):
 def test_compute_signal_score_component_behavior_and_clamping(monkeypatch):
     """Extreme weighted components should still clamp total score to [-10, +10]."""
     monkeypatch.setattr(
-        "src.signals.ASSET_CLASS_WEIGHTS",
+        "pulseengine.core.signals.ASSET_CLASS_WEIGHTS",
         {
             "Stress": {
                 "trend": 5.0,

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -26,8 +26,8 @@ import textwrap
 
 import pytest
 
-from src.news import deduplicate_articles, _jaccard, _normalize_title
-from config.settings import DEDUP_SIMILARITY_THRESHOLD
+from pulseengine.core.news import deduplicate_articles, _jaccard, _normalize_title
+from pulseengine.core.config import DEDUP_SIMILARITY_THRESHOLD
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -201,7 +201,7 @@ def _sleep_inside_semaphore(func) -> list[int]:
 
 def test_fetch_price_history_sleep_outside_semaphore():
     """time.sleep must not be called while holding the yfinance semaphore."""
-    from src.price import fetch_price_history
+    from pulseengine.core.price import fetch_price_history
     bad = _sleep_inside_semaphore(fetch_price_history)
     assert not bad, (
         f"fetch_price_history: time.sleep() found inside _yf_semaphore at line(s) {bad}. "
@@ -211,7 +211,7 @@ def test_fetch_price_history_sleep_outside_semaphore():
 
 def test_fetch_via_ticker_history_sleep_outside_semaphore():
     """Same invariant for the Ticker.history() fallback fetcher."""
-    from src.price import _fetch_via_ticker_history
+    from pulseengine.core.price import _fetch_via_ticker_history
     bad = _sleep_inside_semaphore(_fetch_via_ticker_history)
     assert not bad, (
         f"_fetch_via_ticker_history: time.sleep() found inside _yf_semaphore at line(s) {bad}."

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,19 +5,15 @@ Goal: pipelines execute without crashing and return minimally usable output.
 Not testing exact structure — testing that the output is there and in range.
 
 All network calls are mocked via conftest fixtures.
-
-Imports from app (the backward-compat shim) to verify the shim itself works.
-New tests added below also import directly from src.engine to verify the
-canonical path.
 """
 
 from __future__ import annotations
 
-from app.analysis import analyse_asset, run_full_scan
-from src.errors import DataFetchError
+from pulseengine.core.app import analyse_asset, run_full_scan
+from pulseengine.core.errors import DataFetchError
 
 
-# ── analyse_asset (via app shim) ──────────────────────────────────────────────
+# ── analyse_asset ─────────────────────────────────────────────────────────────
 
 def test_analyse_asset_runs(mock_price_history, storage_dir, synthetic_articles):
     """Happy path: pipeline completes and returns a dict."""
@@ -37,7 +33,7 @@ def test_analyse_asset_has_signal_in_range(mock_price_history, storage_dir, synt
 
 def test_analyse_asset_no_price_data_does_not_crash(mocker, storage_dir, synthetic_articles):
     """When price fetch returns None, the pipeline must still return a dict (not raise)."""
-    mocker.patch("src.engine.fetch_price_history", return_value=None)
+    mocker.patch("pulseengine.core.app.fetch_price_history", return_value=None)
     result = analyse_asset("Gold", "GC=F", "Commodities", synthetic_articles,
                            with_market_ctx=False)
     assert isinstance(result, dict)
@@ -46,7 +42,7 @@ def test_analyse_asset_no_price_data_does_not_crash(mocker, storage_dir, synthet
 
 def test_analyse_asset_fetch_failure_is_structured(mocker, storage_dir, synthetic_articles):
     """A real fetch failure should be represented explicitly in the result."""
-    mocker.patch("src.engine.fetch_price_history", side_effect=DataFetchError("boom"))
+    mocker.patch("pulseengine.core.app.fetch_price_history", side_effect=DataFetchError("boom"))
     result = analyse_asset("Gold", "GC=F", "Commodities", synthetic_articles,
                            with_market_ctx=False)
     assert isinstance(result, dict)
@@ -90,9 +86,9 @@ def test_run_full_scan_surfaces_structured_fetch_errors(mocker, ohlcv_df,
             raise DataFetchError("boom")
         return ohlcv_df(price_series_rising)
 
-    mocker.patch("src.engine.fetch_price_history", side_effect=_fetch_side_effect)
-    mocker.patch("src.engine.fetch_news_articles", return_value=synthetic_articles)
-    mocker.patch("src.engine.analyse_market_context", return_value=None)
+    mocker.patch("pulseengine.core.app.fetch_price_history", side_effect=_fetch_side_effect)
+    mocker.patch("pulseengine.core.app.fetch_news_articles", return_value=synthetic_articles)
+    mocker.patch("pulseengine.core.app.analyse_market_context", return_value=None)
 
     result = run_full_scan()
     error_entries = [
@@ -104,14 +100,3 @@ def test_run_full_scan_surfaces_structured_fetch_errors(mocker, ohlcv_df,
 
     assert error_entries
     assert error_entries[0]["type"] == "data_fetch_error"
-
-
-# ── Direct src.engine import (canonical path) ─────────────────────────────────
-
-def test_src_engine_analyse_asset_runs(mock_price_history, storage_dir, synthetic_articles):
-    """Importing directly from src.engine must also work."""
-    from src.engine import analyse_asset as engine_analyse_asset
-    result = engine_analyse_asset("Gold", "GC=F", "Commodities", synthetic_articles,
-                                  with_market_ctx=False)
-    assert isinstance(result, dict)
-    assert "signal" in result

--- a/tests/test_storage_and_scan.py
+++ b/tests/test_storage_and_scan.py
@@ -7,9 +7,9 @@ import gzip
 import json
 from pathlib import Path
 
-from app.backtest import evaluate_signal_accuracy
-from app.scan import run_scan
-from storage import storage
+from pulseengine.core.backtest import evaluate_signal_accuracy
+from pulseengine.local.scan import run_scan
+from pulseengine.core import storage
 
 
 def _write_snapshot_file(base_dir: Path, asset: str, date: dt.date, payload: dict) -> Path:
@@ -92,9 +92,9 @@ def test_retention_policy_and_cleanup_with_temp_dir(storage_dir):
 
 def test_run_scan_dry_run_completes_without_writing(mocker):
     """Dry-run scans should complete and skip persistence of summary files."""
-    mocker.patch("app.scan.fetch_news_articles", return_value=[])
+    mocker.patch("pulseengine.local.scan.fetch_news_articles", return_value=[])
     mocker.patch(
-        "app.scan.analyse_asset",
+        "pulseengine.local.scan.analyse_asset",
         return_value={
             "signal": {"score": 0.0, "label": "Neutral"},
             "metrics": {


### PR DESCRIPTION
  - Replace stale data banner+button with a quiet caption showing age and refresh status
  - Add @st.fragment(run_every=5) poller that triggers a full page rerun when scan finishes
  - Fix shadow of outer 'ticker' variable in _build_snapshot_price_cache
  - Migrate all test imports from legacy src/app/config.settings paths to pulseengine.core.*
  - Fix _FakeVader.polarity_scores to be @staticmethod (self was unused)