### PR TITLE
refactor(core): replace Optional[X] with X | None across pulseengine/core

### DIFF
--- a/pulseengine/core/context.py
+++ b/pulseengine/core/context.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional
 
 from .config import (
     MARKET_BENCHMARK,
@@ -43,8 +42,8 @@ log = logging.getLogger(__name__)
 def analyse_market_context(
     asset_name: str,
     category: str,
-    asset_change: Optional[float],
-    price_cache: Optional[dict[str, float]] = None,
+    asset_change: float | None,
+    price_cache: dict[str, float] | None = None,
 ) -> dict:
     """
     Compare the asset's move against sector peers and the broad market
@@ -83,10 +82,10 @@ def analyse_market_context(
 
     # ── Peer comparison (parallel) ───────────────────────────────────────────
     peers = SECTOR_PEERS.get(asset_name, [])
-    peer_data: dict[str, Optional[float]] = {}
+    peer_data: dict[str, float | None] = {}
     peer_errors: dict[str, dict] = {}
 
-    def _fetch_peer(peer_name: str) -> tuple[str, Optional[float], Optional[dict]]:
+    def _fetch_peer(peer_name: str) -> tuple[str, float | None, dict | None]:
         peer_ticker = _find_ticker(peer_name)
         if not peer_ticker:
             return peer_name, None, None
@@ -128,7 +127,7 @@ def analyse_market_context(
     # ── Benchmark comparison ─────────────────────────────────────────────────
     bench_ticker = MARKET_BENCHMARK.get(category)
     if bench_ticker:
-        bench_chg: Optional[float] = None
+        bench_chg: float | None = None
         if price_cache is not None and bench_ticker in price_cache:
             bench_chg = price_cache[bench_ticker]
         else:
@@ -176,11 +175,11 @@ _CATEGORY_MAP: dict[str, str] = {
 }
 
 
-def _find_ticker(asset_name: str) -> Optional[str]:
+def _find_ticker(asset_name: str) -> str | None:
     """Return the ticker for *asset_name*."""
     return _TICKER_MAP.get(asset_name)
 
 
-def find_category(asset_name: str) -> Optional[str]:
+def find_category(asset_name: str) -> str | None:
     """Return the category string for *asset_name*, or None if not tracked."""
     return _CATEGORY_MAP.get(asset_name)

--- a/pulseengine/core/explanation.py
+++ b/pulseengine/core/explanation.py
@@ -17,7 +17,6 @@ Pipeline role (step 10 of the full engine):
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 from .config import (
     PRICE_CHANGE_THRESHOLD,
@@ -35,9 +34,9 @@ def build_explanation(
     asset_name: str,
     metrics: dict,
     related_news: list[dict],
-    market_ctx: Optional[dict] = None,
-    momentum: Optional[dict] = None,
-    signal: Optional[dict] = None,
+    market_ctx: dict | None = None,
+    momentum: dict | None = None,
+    signal: dict | None = None,
 ) -> dict:
     """
     Produce a structured explanation with:
@@ -463,7 +462,7 @@ def _build_why_it_matters(
 def _build_verdict(
     name: str,
     direction: str,
-    change: Optional[float],
+    change: float | None,
     factors: list[dict],
     news: list[dict],
 ) -> str:
@@ -496,9 +495,9 @@ def _build_verdict(
 def _assess_confidence(
     factors: list[dict],
     news: list[dict],
-    ctx: Optional[dict],
-    metrics: Optional[dict] = None,
-    contradictions: Optional[list[dict]] = None,
+    ctx: dict | None,
+    metrics: dict | None = None,
+    contradictions: list[dict] | None = None,
 ) -> dict:
     """
     Return a dict: {level, score, reasons, increases, decreases}.
@@ -609,7 +608,7 @@ def _assess_confidence(
 
 # ── Formatting helper ─────────────────────────────────────────────────────────
 
-def _fmt_pct(val: Optional[float]) -> str:
+def _fmt_pct(val: float | None) -> str:
     if val is None:
         return "N/A"
     sign = "+" if val > 0 else ""

--- a/pulseengine/core/news.py
+++ b/pulseengine/core/news.py
@@ -22,7 +22,6 @@ import re
 import threading
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Optional
 from urllib.parse import urlparse
 
 import feedparser
@@ -184,7 +183,7 @@ def cluster_articles(articles: list[dict]) -> dict[str, list[dict]]:
 def get_display_clusters(
     news: list[dict],
     max_clusters: int = 2,
-    min_relevance: Optional[float] = None,
+    min_relevance: float | None = None,
 ) -> dict:
     """
     Return top N topic clusters for display, filtering low-relevance noise.
@@ -327,7 +326,7 @@ def generate_keywords(ticker: str) -> list[str]:
 
 # ── Private helpers ───────────────────────────────────────────────────────────
 
-def _parse_pub_date(entry) -> Optional[dt.datetime]:
+def _parse_pub_date(entry) -> dt.datetime | None:
     for attr in ("published_parsed", "updated_parsed"):
         parsed = getattr(entry, attr, None)
         if parsed:

--- a/pulseengine/core/price.py
+++ b/pulseengine/core/price.py
@@ -17,7 +17,6 @@ import math
 import tempfile
 import threading
 import time
-from typing import Optional
 
 import pandas as pd
 import yfinance as yf
@@ -49,7 +48,7 @@ _yf_semaphore = threading.Semaphore(PRICE_FETCH_WORKERS)
 def fetch_price_history(
     ticker: str,
     days: int = LOOKBACK_DAYS,
-) -> Optional[pd.DataFrame]:
+) -> pd.DataFrame | None:
     """Download OHLCV history for *ticker*.
 
     Returns None when the market simply has no data for the requested window.
@@ -110,7 +109,7 @@ def fetch_price_history(
     return None
 
 
-def _fetch_via_ticker_history(ticker: str, days: int) -> Optional[pd.DataFrame]:
+def _fetch_via_ticker_history(ticker: str, days: int) -> pd.DataFrame | None:
     """
     Fallback fetcher using yf.Ticker.history().
 
@@ -143,7 +142,7 @@ def _fetch_via_ticker_history(ticker: str, days: int) -> Optional[pd.DataFrame]:
 
 # ── Price metrics ────────────────────────────────────────────────────────────
 
-def compute_price_metrics(df: Optional[pd.DataFrame]) -> dict:
+def compute_price_metrics(df: pd.DataFrame | None) -> dict:
     """Return a dict of price analytics derived from a price DataFrame."""
     if df is None or df.empty:
         return {}
@@ -158,7 +157,7 @@ def compute_price_metrics(df: Optional[pd.DataFrame]) -> dict:
     if not math.isfinite(latest):
         return {}
 
-    def safe_pct(n: int) -> Optional[float]:
+    def safe_pct(n: int) -> float | None:
         if len(close) > n:
             old = float(close.iloc[-(n + 1)])
             if abs(old) < 1e-9 or not math.isfinite(old):
@@ -202,7 +201,7 @@ def classify_trend(series: pd.Series) -> str:
 
 # ── Momentum metrics ─────────────────────────────────────────────────────────
 
-def compute_momentum_metrics(df: Optional[pd.DataFrame]) -> dict:
+def compute_momentum_metrics(df: pd.DataFrame | None) -> dict:
     """
     Return RSI, rate-of-change, trend strength, and momentum acceleration.
     Falls back to neutral defaults when data is insufficient.

--- a/pulseengine/core/signals.py
+++ b/pulseengine/core/signals.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import re
-from typing import Optional
 
 from .config import (
     ASSET_CLASS_WEIGHTS,
@@ -53,7 +52,7 @@ def _kw_re(kw: str) -> re.Pattern:
 def correlate_news(
     asset_name: str,
     articles: list[dict],
-    keywords: Optional[list[str]] = None,
+    keywords: list[str] | None = None,
 ) -> list[dict]:
     """
     Match articles to *asset_name* using weighted keywords, a recency bonus,
@@ -142,8 +141,8 @@ def compute_signal_score(
     metrics: dict,
     momentum: dict,
     news: list[dict],
-    market_ctx: Optional[dict] = None,
-    category: Optional[str] = None,
+    market_ctx: dict | None = None,
+    category: str | None = None,
 ) -> dict:
     """
     Compute a composite bullish/bearish signal for an asset.


### PR DESCRIPTION
## Summary
  - Removed `from typing import Optional` from all 5 affected modules in `pulseengine/core/`
  - Replaced all `Optional[X]` annotations with the modern `X | None` union syntax (PEP 604)
  - `price.py` already had `Exception | None` on one line — the rest of the file is now consistent

  Closes #48

  ## Files changed
  - `pulseengine/core/signals.py`
  - `pulseengine/core/price.py`
  - `pulseengine/core/news.py`
  - `pulseengine/core/context.py`
  - `pulseengine/core/explanation.py`

  ## Notes
  All modules already had `from __future__ import annotations`, so `X | None` is safe on all supported Python versions (3.11–3.14). No runtime behaviour changed.